### PR TITLE
Enable multiple filenames in excel import

### DIFF
--- a/xslt/Filename_helper.xslt
+++ b/xslt/Filename_helper.xslt
@@ -30,8 +30,9 @@ This stylesheet creates a template which is called in another stylsheet, and cre
     <xsl:template name="filename">
         <xsl:param name="file"/>
         <xsl:value-of
-            select="replace(replace(Accession,'.pdf',''),'[^0-9A-Za-z]','_')"/>
+            select="replace(normalize-space($file),'[^0-9A-Za-z.]','_')"/>
             <xsl:choose>
+            <xsl:when test="contains($file, '.')"></xsl:when>
             <xsl:when test="Format|format='application/mp4'">.mp4</xsl:when>
             <xsl:when test="Format|format='application/mp3'">.mp3</xsl:when>
             <xsl:when test="Format|format='image/tiff'">.tif</xsl:when>

--- a/xslt/SplitField_helper.xslt
+++ b/xslt/SplitField_helper.xslt
@@ -20,6 +20,32 @@ This stylesheet creates a group of templates for normalizing data entry errors, 
     xmlns:edm="http://www.europeana.eu/schemas/edm/" xmlns:foaf="http://xmlns.com/foaf/0.1/"
     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
     
+    <!-- this portion of the XSLT creates a named template for Filename (or Accession), identifies delimiters from the input file and splits them into seperate dcterms:alternative elements, 
+       it also strips out any full stops-->
+    <xsl:template name="FilenameSplit" match="text()">
+        <xsl:param name="FilenameText" select="Accession"/>
+        <xsl:if test="string-length($FilenameText)">
+            <xsl:choose>
+            <xsl:when test="($FilenameText = Accession)">
+                <tufts:filename type="representative">
+                    <xsl:call-template name="filename">
+                        <xsl:with-param name="file" select="substring-before(concat($FilenameText, '|'), '|')"/>
+                    </xsl:call-template>
+                </tufts:filename>
+            </xsl:when>
+            <xsl:otherwise>
+                <tufts:filename>
+                    <xsl:call-template name="filename">
+                        <xsl:with-param name="file" select="substring-before(concat($FilenameText, '|'), '|')"/>
+                    </xsl:call-template>
+                </tufts:filename>
+            </xsl:otherwise>
+            </xsl:choose>
+            <xsl:call-template name="FilenameSplit">
+                <xsl:with-param name="FilenameText" select="substring-after($FilenameText, '|')"/>
+            </xsl:call-template>
+        </xsl:if>
+    </xsl:template>
     <!-- this portion of the XSLT creates a named template for altTitle, identifies delimiters from the input file and splits them into seperate dcterms:alternative elements, 
        it also strips out any full stops-->
     <xsl:template name="altTitleSplit" match="text()">

--- a/xslt/excel_to_dc.xslt
+++ b/xslt/excel_to_dc.xslt
@@ -80,11 +80,11 @@ This stylesheet converts Excel metadata to qualified Dublin Core based on the ma
         </OAI-PMH>
     </xsl:template>
     <xsl:template match="Accession" name="file">
-        <tufts:filename type="representative">
-            <xsl:call-template name="filename">
-                <xsl:with-param name="file"/>
-            </xsl:call-template>
-        </tufts:filename>
+        <xsl:call-template name="FilenameSplit">
+            <xsl:with-param name="FilenameText">
+                <xsl:value-of select="Accession"/>
+            </xsl:with-param>
+        </xsl:call-template>
     </xsl:template>
     <xsl:template match="Process" name="visibility">
         <xsl:choose>


### PR DESCRIPTION
Changes parser for first Excel column to allow multiple filenames separated by a pipe character First filename will be tagged "representative"
If a filename has a filename extension, it is retained rather than overridden by the Format column

Closes #11