### PR TITLE
Update excel_to_dc.xslt

### DIFF
--- a/xslt/Filename_helper.xslt
+++ b/xslt/Filename_helper.xslt
@@ -21,6 +21,7 @@ This stylesheet creates a template which is called in another stylsheet, and cre
             <xsl:when test="Format|format='application/mp3'">.mp3</xsl:when>
             <xsl:when test="Format|format='image/tiff'">.tif</xsl:when>
             <xsl:when test="Format|format='image/jpg'">.jpg</xsl:when>
+            <xsl:when test="Format|format='image/gif'">.gif</xsl:when>
             <xsl:when test="Format|format='video/quicktime'">.mov</xsl:when>
             <xsl:when test="Format|format='audio/wav'">.wav</xsl:when>
             <xsl:otherwise>.archival.pdf</xsl:otherwise>
@@ -37,6 +38,7 @@ This stylesheet creates a template which is called in another stylsheet, and cre
             <xsl:when test="Format|format='application/mp3'">.mp3</xsl:when>
             <xsl:when test="Format|format='image/tiff'">.tif</xsl:when>
             <xsl:when test="Format|format='image/jpg'">.jpg</xsl:when>
+            <xsl:when test="Format|format='image/gif'">.gif</xsl:when>
             <xsl:when test="Format|format='video/quicktime'">.mov</xsl:when>
             <xsl:when test="Format|format='audio/wav'">.wav</xsl:when>
             <xsl:otherwise>.pdf</xsl:otherwise>

--- a/xslt/excel_to_dc.xslt
+++ b/xslt/excel_to_dc.xslt
@@ -138,7 +138,7 @@ This stylesheet converts Excel metadata to qualified Dublin Core based on the ma
             <xsl:when test="Format = 'image/jpg'">
                 <model:hasModel>Image</model:hasModel>
             </xsl:when>
-			<xsl:when test="Format = 'image/gif'">
+                <xsl:when test="Format = 'image/gif'">
                 <model:hasModel>Image</model:hasModel>
             </xsl:when>
             <xsl:when test="Format = 'video/quicktime'">
@@ -256,7 +256,7 @@ This stylesheet converts Excel metadata to qualified Dublin Core based on the ma
             <xsl:when test="Format = 'image/jpg'">
                 <dc:type>http://purl.org/dc/dcmitype/Image</dc:type>
             </xsl:when>
-			<xsl:when test="Format = 'image/gif'">
+                <xsl:when test="Format = 'image/gif'">
                 <dc:type>http://purl.org/dc/dcmitype/Image</dc:type>
             </xsl:when>
             <xsl:when test="Format = 'video/quicktime'">

--- a/xslt/excel_to_dc.xslt
+++ b/xslt/excel_to_dc.xslt
@@ -138,6 +138,9 @@ This stylesheet converts Excel metadata to qualified Dublin Core based on the ma
             <xsl:when test="Format = 'image/jpg'">
                 <model:hasModel>Image</model:hasModel>
             </xsl:when>
+			<xsl:when test="Format = 'image/gif'">
+                <model:hasModel>Image</model:hasModel>
+            </xsl:when>
             <xsl:when test="Format = 'video/quicktime'">
                 <model:hasModel>Video</model:hasModel>
             </xsl:when>
@@ -251,6 +254,9 @@ This stylesheet converts Excel metadata to qualified Dublin Core based on the ma
                 <dc:type>http://purl.org/dc/dcmitype/Image</dc:type>
             </xsl:when>
             <xsl:when test="Format = 'image/jpg'">
+                <dc:type>http://purl.org/dc/dcmitype/Image</dc:type>
+            </xsl:when>
+			<xsl:when test="Format = 'image/gif'">
                 <dc:type>http://purl.org/dc/dcmitype/Image</dc:type>
             </xsl:when>
             <xsl:when test="Format = 'video/quicktime'">


### PR DESCRIPTION
added gif image file format to xslt to allow for "image/gif" to be valid value in the excel sheet's format column and be mapped to the "image" work type in Mira.